### PR TITLE
Fix clang error "error: declaration of 'Passed' shadows template parameter"

### DIFF
--- a/include/vta/algorithms.hpp
+++ b/include/vta/algorithms.hpp
@@ -606,7 +606,7 @@ namespace detail {
 template <template <class> class Predicate, typename... Passed>
 struct filter_helper;
 
-template <template <class> class Predicate, bool Passed, typename... Passed>
+template <template <class> class Predicate, bool BPassed, typename... Passed>
 struct next_has_passed;
 
 template <template <class> class Predicate, typename... Passed>


### PR DESCRIPTION
template<> struct next_has_passed has a bool parameter and a parameter pack both named Passed. Clang complains about template parameter shadowing. A simple rename fixes it, tested with clang 3.6.0.
